### PR TITLE
Partial Filipino Translation - 1 177 translated words

### DIFF
--- a/tl/controllers/request-response.rst
+++ b/tl/controllers/request-response.rst
@@ -299,7 +299,7 @@ Para ma-access ang sesyon para sa ibinigay na hiling na ginamit sa ``session()``
 
     $userName = $this->request->session()->read('Auth.User.name');
 
-Para sa karagdagangn impormasyon, tingnan ang :doc:`/development/sessions` na dokumentasyon para sa kung papaano
+Para sa karagdagang impormasyon, tingnan ang :doc:`/development/sessions` na dokumentasyon para sa kung papaano
 gamitin ang sesyon na object.
 
 Host at Domain na Pangalan
@@ -326,8 +326,8 @@ Binabalik sa host ang iyong aplikasyon sa::
     // Nagpapakita ng 'my.dev.example.org'
     echo $request->host();
 
-Pagbabasa ng HTTP na Pamaraan
------------------------------
+Pagbabasa ng HTTP na Pamamaraan
+-------------------------------
 
 .. php:method:: getMethod()
 
@@ -339,8 +339,8 @@ Binabalik ang HTTP na pamamaraan ang hiling na ginagawa sa::
     // Bago ang 3.4.0
     echo $request->method();
 
-Paghihigpit na kung saan ang HTTP na pamaraan ay isang Aksyon na Tinatanggap
-----------------------------------------------------------------------------
+Pinaghihigpitan kung Anong HTTP na pamamaraan ang Tinatanggap ng Aksyon
+-----------------------------------------------------------------------
 
 .. php:method:: allowMethod($methods)
 
@@ -378,7 +378,7 @@ Ang CakePHP ay gagawin itong magagamit sa pamamagitan ng apache na tiyak na mga 
 
 .. php:method:: referer($local = false)
 
-Binabalik ang nagre-refer sa address para sa hiling.
+Binabalik ang nagre-refer na address para sa hiling.
 
 .. php:method:: clientIp()
 
@@ -389,7 +389,7 @@ Pagtitiwala sa Proxy na mga Header
 
 Kung ang iyong aplikasyon ay sa likod ng isang load balancer o tumatakbo sa isang cloud na serbisyo, ikaw
 ay madalas na makakuha ng load balancer na host, port at scheme sa iyong mga hiling. Madalas
-ng load ng mga balander ay nagpapadala din ng ``HTTP-X-Forwarded-*`` na mga header na may orihinal
+ang load na mga balancer ay nagpapadala din ng ``HTTP-X-Forwarded-*`` na mga header na may orihinal
 na mga halaga. Ang naipasa na mga header ay hindi magagamit sa CakePHP sa labas ng kahon. Upang
 makuha ang hiling na object gumagamit nitong mga header set na ``trustProxy`` na katangian sa
 ``true``::
@@ -407,7 +407,7 @@ Pagsusuri sa Tinanggap na mga Header
 
 .. php:method:: accepts($type = null)
 
-Malaman kung ano ang nilalaman ng mga uri sa kliyenteng tinatanggap, o suriin kung ito ay tumatanggap ng
+Alamin kung ano ang nilalaman ng mga uri sa kliyenteng tinatanggap, o suriin kung ito ay tumatanggap ng
 isang partikular na uri ng nilalaman.
 
 Kunin ang lahat ng mga uri::
@@ -420,14 +420,14 @@ Suriin para sa isang solong uri::
 
 .. php:method:: acceptLanguage($language = null)
 
-Kunin ang lahat ng mga language na tinatanggap sa kliyente,
-o suriin kung ang tiyak na language ay tinatanggap.
+Kunin ang lahat ng mga lengguwahe na tinatanggap sa kliyente,
+o suriin kung ang tiyak na lengguwahe ay tinatanggap.
 
-Kunin ang listahan sa tinatanggap na mga language::
+Kunin ang listahan sa tinatanggap na mga lengguwahe::
 
     $acceptsLanguages = $this->request->acceptLanguage();
 
-Suriin kung ang isang tiyak na language ay tinatanggap::
+Suriin kung ang isang tiyak na lengguwahe ay tinatanggap::
 
     $acceptsSpanish = $this->request->acceptLanguage('es-es');
 
@@ -436,7 +436,7 @@ Suriin kung ang isang tiyak na language ay tinatanggap::
 Mga Cookie
 ----------
 
-Hiling na mga cookie ay maaaring mabasa gamit ang isang bilang ng mga pamamaraan::
+Ang hiling na mga cookie ay maaaring mabasa gamit ang isang bilang ng mga pamamaraan::
 
     // Kunin ang cookie na halaga, o null kung ang cookie ay nawawala.
     $rememberMe = $this->request->getCookie('remember_me');
@@ -464,21 +464,21 @@ Tugon
 .. php:class:: Response
 
 Ang :php:class:`Cake\\Http\\Response` ay isang default na tugon na class sa CakePHP.
-Ito ay nagpapaikut-ikot sa bilang ng mga tampok atfunctionality para bumuo ng HTTP
+Ito ay nag-eencapsulate sa ilang mga tampok at functionality para sa pagbubuo ng HTTP
 na mga tugon sa iyong aplikasyon. Ito rin ay tumutulong sa pagsusubok, dahil maaari itong
-naka-mock/naka-stubb na nagpapahintulot sa iyo na siyasatin ang mga header na maipapadala.
+naka-mock/naka-stub na nagpapahintulot sa iyo na siyasatin ang mga header na maipapadala.
 Tulad ng :php:class:`Cake\\Http\\ServerRequest`, :php:class:`Cake\\Http\\Response`
-nagsasama ng bilang ng mga pamamaraan na dati ay nakita sa :php:class:`Controller`,
+na nagsasama ng ilang mga pamamaraan na dati ay nakita sa :php:class:`Controller`,
 :php:class:`RequestHandlerComponent` at :php:class:`Dispatcher`. Ang lumang
-mga pamamaraan ay hindi na magagamit sa pabot sa pagagamit sa :php:class:`Cake\\Http\\Response`.
+mga pamamaraan ay hindi na magagamit sa pabor ng paggamit sa :php:class:`Cake\\Http\\Response`.
 
-``Response`` ay nagbibigay ng isang interface para balutin ang karaniwang tugon na may kaugnayad
+``Response`` ay nagbibigay ng isang interface para balutin ang karaniwang tugon na may kaugnayan
 na mga gawain tulad sa:
 
 * Pagpapadala ng mga header para sa mga nagre-redirect.
 * Pagpapadala ng nilalaman na uri ng mga header.
 * Pagpapadala sa anumang header.
-* Pagpapadala ng tugon sa katawan.
+* Pagpapadala ng tugon na katawan.
 
 Pakikitungo na may nilalaman na mga uri
 ---------------------------------------
@@ -499,7 +499,7 @@ na may nilalaman na mga uri na hindi itinayo sa Tugon, maaari kang makamapa sa k
     // Bago ang 3.4.0
     $this->response->type('vcf');
 
-Karaniwan, gusto mo magmapa sa karagdagang nilalaman na mga uri sa iyong controller sa
+Karaniwan, gusto mong magmapa sa karagdagang nilalaman na mga uri sa iyong controller sa
 :php:meth:`~Controller::beforeFilter()` na callback, maaari kang gumamit ng
 awtomatiko na view na lumilipat na mga tampok sa :php:class:`RequestHandlerComponent` kung ikaw
 ay gumgamit nito.
@@ -511,7 +511,7 @@ Pagpapadala ng mga File
 
 .. php:method:: withFile($path, $options = [])
 
-May mga oras na gusto mong mapadala ng mga file bilang mga tugon para sa iyong mga hiling.
+May mga panahon na gusto mong mapadala ng mga file bilang mga tugon para sa iyong mga hiling.
 Maaari mong maisagawa ito sa pamamagitan ng paggamit sa :php:meth:`Cake\\Http\\Response::withFile()`::
 
     public function sendFile($id)
@@ -536,7 +536,7 @@ sa `Cake\\Http\\Reponse::$_mimeTypes`. Maaari kang magdagdag ng bagong mga uri b
 :php:meth:`Cake\\Http\\Response::withFile()` sa pamamagitan sa paggamit ng
 :php:meth:`Cake\\Http\\Response::withType()` na pamamaraan.
 
-Kung gusto mo, maaari ka ding pilitin ang isang file na ma-download sa halip na ipinapakita sa
+Kung gusto mo, maaari mo ring pilitin ang isang file na ma-download sa halip na ipinapakita sa
 browser sa pamamagitan ng pagtutukoy sa mga opsyon::
 
     $response = $this->response->withFile(
@@ -594,7 +594,7 @@ Pagtatakda ng mga Header
 .. php:method:: withHeader($header, $value)
 
 Pagtatakda ng mga header ay nagawa na may :php:meth:`Cake\\Http\\Response::withHeader()`
-na pamamaraan. Tulad ng lahat sa PSR-7 na interface na mga pamamaraan, itong pamaraan ay bumabalik ng *new*
+na pamamaraan. Tulad ng lahat sa PSR-7 na interface na mga pamamaraan, itong pamaraan ay bumabalik ng *bagong*
 instance na may bagong header::
 
     // Pagdagdag/pagpalit ng isang header
@@ -610,10 +610,10 @@ instance na may bagong header::
     // Bago ang 3.4.0 - Itakda ang isang header
     $this->response->header('Location', 'http://example.com');
 
-Mga headers ay hindi pinadala kung naitakda. Sa halip, sila ay gaganapin hanggang ang tugon ay
+Ang mga header ay hindi pinadala kung naitakda. Sa halip, sila ay gaganapin hanggang ang tugon ay
 napalabas sa pamamagitan ng ``Cake\Http\Server``.
 
-Maaari mo na ngayong gumamit ng kaginhawaan na pamamaraan sa
+Maaari ka na ngayong gumamit ng kaginhawaan na pamamaraan sa
 :php:meth:`Cake\\Http\\Response::withLocation()` upang direkta na itakda o kunin ang
 pag-redirect na lokasyon na header.
 
@@ -645,9 +645,9 @@ Upang itakda ang tugon na katawan, gamitin ang ``withBody()`` na pamamaraan, na 
     $this->response->body('My Body');
 
 Siguraduhin na ang ``$stream`` ay isang :php:class:`Psr\\Http\\Message\\StreamInterface` na object.
-Tingmam sa ibaba kung papaano lumikha ng isang bagong stream.
+Tingnan sa ibaba kung papaano lumikha ng isang bagong stream.
 
-Maaari mo ring mag-stream ng mga tugon mula sa mga file na gamit ang :php:class:`Zend\\Diactoros\\Stream` na mga stream::
+Maaari ka ring mag-stream ng mga tugon mula sa mga file na gamit ang :php:class:`Zend\\Diactoros\\Stream` na mga stream::
 
     // Upang i-stream mula sa file
     use Zend\Diactoros\Stream;
@@ -716,7 +716,7 @@ sa ganun::
 
 .. php:method:: withCache($since, $time = '+1 day')
 
-Maaari mo ring sabihin ang mga kliyente na gusto mo sa kanila upang i-cache ang mga tugon. Sa pamamagitan sa paggamit
+Maaari mo ring sabihan ang mga kliyente na gusto mong mag-cache sila ng mga tugon. Sa pamamagitan sa paggamit
 ng :php:meth:`Cake\\Http\\Response::withCache()`::
 
     public function index()
@@ -728,8 +728,8 @@ ng :php:meth:`Cake\\Http\\Response::withCache()`::
 Ang sabi sa itaas sa mga kliyente upang i-cache ang resultang tugon hanggang sa limang araw,
 sana ay mapadali ang karanasan ng iyong mga binisita.
 Ang ``withCache()`` na pamamaraan ay nagtatakda ng ``Last-Modified`` na halaga para sa unang
-argumento. ``Expires`` na header at ang ``max-age`` na direktiba ay nakabatay batay sa
-pangalawang parameter. Ang pag-cache na pagkokontrol ng ``public`` direktiba ay itinakda rin.
+argumento. Ang ``Expires`` na header at ang ``max-age`` direktibo ay nakatakda batay sa
+pangalawang parameter. Ang pag-cache na pagkokontrol ng ``public`` direktibo ay itinakda rin.
 
 .. _cake-response-caching:
 

--- a/tl/controllers/request-response.rst
+++ b/tl/controllers/request-response.rst
@@ -292,278 +292,278 @@ Mayroong ilang mga built-in na mga detektor na magagamit mo:
 .. versionadded:: 3.3.0
     Ang mga Detektor ay maaaring tumanggap ng karagdagang mga parameter batay sa 3.3.0.
 
-Session Data
-------------
+Sesyon na Datos
+---------------
 
-To access the session for a given request use the ``session()`` method::
+Para ma-access ang sesyon para sa ibinigay na hiling na ginamit sa ``session()`` na pamamaraan::
 
     $userName = $this->request->session()->read('Auth.User.name');
 
-For more information, see the :doc:`/development/sessions` documentation for how
-to use the session object.
+Para sa karagdagangn impormasyon, tingnan ang :doc:`/development/sessions` na dokumentasyon para sa kung papaano
+gamitin ang sesyon na object.
 
-Host and Domain Name
---------------------
+Host at Domain na Pangalan
+--------------------------
 
 .. php:method:: domain($tldLength = 1)
 
-Returns the domain name your application is running on::
+Binabalik ang domain na pangalan sa iyong aplikasyon na pinatakbo sa::
 
-    // Prints 'example.org'
+    // Nagpapakita ng 'example.org'
     echo $request->domain();
 
 .. php:method:: subdomains($tldLength = 1)
 
-Returns the subdomains your application is running on as an array::
+Binabalik ang mga subdomain sa iyong aplikasyon na iyong pinatakbo bilang isang array::
 
-    // Returns ['my', 'dev'] for 'my.dev.example.org'
+    // Binabalik ng ['my', 'dev'] para sa 'my.dev.example.org'
     $subdomains = $request->subdomains();
 
 .. php:method:: host()
 
-Returns the host your application is on::
+Binabalik sa host ang iyong aplikasyon sa::
 
-    // Prints 'my.dev.example.org'
+    // Nagpapakita ng 'my.dev.example.org'
     echo $request->host();
 
-Reading the HTTP Method
------------------------
+Pagbabasa ng HTTP na Pamaraan
+-----------------------------
 
 .. php:method:: getMethod()
 
-Returns the HTTP method the request was made with::
+Binabalik ang HTTP na pamamaraan ang hiling na ginagawa sa::
 
-    // Output POST
+    // Output ng POST
     echo $request->getMethod();
 
-    // Prior to 3.4.0
+    // Bago ang 3.4.0
     echo $request->method();
 
-Restricting Which HTTP method an Action Accepts
------------------------------------------------
+Paghihigpit na kung saan ang HTTP na pamaraan ay isang Aksyon na Tinatanggap
+----------------------------------------------------------------------------
 
 .. php:method:: allowMethod($methods)
 
-Set allowed HTTP methods. If not matched, will throw
-``MethodNotAllowedException``. The 405 response will include the required
-``Allow`` header with the passed methods::
+Itakda ang pinapayagan na HTTP na mga pamaraan. Kung hindi tumugma, ito ay nagtatapon ng
+``MethodNotAllowedException``. Ang 405 na sagot ay magdaragdag ng kinakailangan na
+``Allow`` na header na may naipasa na mga pamamaraan::
 
     public function delete()
     {
-        // Only accept POST and DELETE requests
+        // Tinatanggap lamang ang POST at DELETE na mga hiling
         $this->request->allowMethod(['post', 'delete']);
         ...
     }
 
-Reading HTTP Headers
---------------------
+Pagbabasa ng HTTP na mga Header
+-------------------------------
 
-Allows you to access any of the ``HTTP_*`` headers that were used
-for the request. For example::
+Nagpapahintulot sa iyo na i-access ang anuman sa ``HTTP_*`` na mga header na iyong ginamit
+para sa hiling. Halimbawa::
 
-    // Get the header as a string
+    // Kunin ang header bilang isang string
     $userAgent = $this->request->getHeaderLine('User-Agent');
 
-    // Get an array of all values.
+    // Kunin ang isang array sa lahat ng mga halaga.
     $acceptHeader = $this->request->getHeader('Accept');
 
-    // Check if a header exists
+    // Suriin kung ang isang header ay umiiral
     $hasAcceptHeader = $this->request->hasHeader('Accept');
 
-    // Prior to 3.4.0
+    // Bago ang 3.4.0
     $userAgent = $this->request->header('User-Agent');
 
-While some apache installs don't make the ``Authorization`` header accessible,
-CakePHP will make it available through apache specific methods as required.
+Habang ang ilang apache na naka-install ay hindi makagawa ng ``Authorization`` na header na mapupuntahan,
+Ang CakePHP ay gagawin itong magagamit sa pamamagitan ng apache na tiyak na mga pamamaraan bilang kinakailangan.
 
 .. php:method:: referer($local = false)
 
-Returns the referring address for the request.
+Binabalik ang nagre-refer sa address para sa hiling.
 
 .. php:method:: clientIp()
 
-Returns the current visitor's IP address.
+Binabalik ang kasalukuyang IP address ng bumisita.
 
-Trusting Proxy Headers
-----------------------
+Pagtitiwala sa Proxy na mga Header
+----------------------------------
 
-If your application is behind a load balancer or running on a cloud service, you
-will often get the load balancer host, port and scheme in your requests. Often
-load balancers will also send ``HTTP-X-Forwarded-*`` headers with the original
-values. The forwarded headers will not be used by CakePHP out of the box. To
-have the request object use these headers set the ``trustProxy`` property to
+Kung ang iyong aplikasyon ay sa likod ng isang load balancer o tumatakbo sa isang cloud na serbisyo, ikaw
+ay madalas na makakuha ng load balancer na host, port at scheme sa iyong mga hiling. Madalas
+ng load ng mga balander ay nagpapadala din ng ``HTTP-X-Forwarded-*`` na mga header na may orihinal
+na mga halaga. Ang naipasa na mga header ay hindi magagamit sa CakePHP sa labas ng kahon. Upang
+makuha ang hiling na object gumagamit nitong mga header set na ``trustProxy`` na katangian sa
 ``true``::
 
     $this->request->trustProxy = true;
 
-    // These methods will now use the proxied headers.
+    // Ito mga pamamaraan ay nagpapahintulot sa iyo na gumamit ng naka-proxy na mga header.
     $port = $this->request->port();
     $host = $this->request->host();
     $scheme = $this->request->scheme();
     $clientIp = $this->request->clientIp();
 
-Checking Accept Headers
------------------------
+Pagsusuri sa Tinanggap na mga Header
+------------------------------------
 
 .. php:method:: accepts($type = null)
 
-Find out which content types the client accepts, or check whether it accepts a
-particular type of content.
+Malaman kung ano ang nilalaman ng mga uri sa kliyenteng tinatanggap, o suriin kung ito ay tumatanggap ng
+isang partikular na uri ng nilalaman.
 
-Get all types::
+Kunin ang lahat ng mga uri::
 
     $accepts = $this->request->accepts();
 
-Check for a single type::
+Suriin para sa isang solong uri::
 
     $acceptsJson = $this->request->accepts('application/json');
 
 .. php:method:: acceptLanguage($language = null)
 
-Get all the languages accepted by the client,
-or check whether a specific language is accepted.
+Kunin ang lahat ng mga language na tinatanggap sa kliyente,
+o suriin kung ang tiyak na language ay tinatanggap.
 
-Get the list of accepted languages::
+Kunin ang listahan sa tinatanggap na mga language::
 
     $acceptsLanguages = $this->request->acceptLanguage();
 
-Check whether a specific language is accepted::
+Suriin kung ang isang tiyak na language ay tinatanggap::
 
     $acceptsSpanish = $this->request->acceptLanguage('es-es');
 
 .. _request-cookies:
 
-Cookies
--------
+Mga Cookie
+----------
 
-Request cookies can be read through a number of methods::
+Hiling na mga cookie ay maaaring mabasa gamit ang isang bilang ng mga pamamaraan::
 
-    // Get the cookie value, or null if the cookie is missing.
+    // Kunin ang cookie na halaga, o null kung ang cookie ay nawawala.
     $rememberMe = $this->request->getCookie('remember_me');
 
-    // Read the value, or get the default of 0
+    // Basahin ang halaga, o kunin ang default sa 0
     $rememberMe = $this->request->getCookie('remember_me', 0);
 
-    // Get all cookies as an hash
+    // Kunin ang lahat ng mga cookie bilang isang hash
     $cookies = $this->request->getCookieParams();
 
-    // Get a CookieCollection instance (starting with 3.5.0)
+    // Kunin ang CookieCollection na instance (na nagsisimula sa 3.5.0)
     $cookies = $this->request->getCookieCollection()
 
-See the :php:class:`Cake\\Http\\Cookie\\CookieCollection` documentation for how
-to work with cookie collection.
+Tingnan ang :php:class:`Cake\\Http\\Cookie\\CookieCollection` na dokumentasyon para sa kung paano
+ipagana gamit ang koleksyon ng cookie.
 
 .. versionadded:: 3.5.0
     ``ServerRequest::getCookieCollection()`` was added in 3.5.0
 
 .. index:: $this->response
 
-Response
-========
+Tugon
+=====
 
 .. php:class:: Response
 
-:php:class:`Cake\\Http\\Response` is the default response class in CakePHP.
-It encapsulates a number of features and functionality for generating HTTP
-responses in your application. It also assists in testing, as it can be
-mocked/stubbed allowing you to inspect headers that will be sent.
-Like :php:class:`Cake\\Http\\ServerRequest`, :php:class:`Cake\\Http\\Response`
-consolidates a number of methods previously found on :php:class:`Controller`,
-:php:class:`RequestHandlerComponent` and :php:class:`Dispatcher`. The old
-methods are deprecated in favour of using :php:class:`Cake\\Http\\Response`.
+Ang :php:class:`Cake\\Http\\Response` ay isang default na tugon na class sa CakePHP.
+Ito ay nagpapaikut-ikot sa bilang ng mga tampok atfunctionality para bumuo ng HTTP
+na mga tugon sa iyong aplikasyon. Ito rin ay tumutulong sa pagsusubok, dahil maaari itong
+naka-mock/naka-stubb na nagpapahintulot sa iyo na siyasatin ang mga header na maipapadala.
+Tulad ng :php:class:`Cake\\Http\\ServerRequest`, :php:class:`Cake\\Http\\Response`
+nagsasama ng bilang ng mga pamamaraan na dati ay nakita sa :php:class:`Controller`,
+:php:class:`RequestHandlerComponent` at :php:class:`Dispatcher`. Ang lumang
+mga pamamaraan ay hindi na magagamit sa pabot sa pagagamit sa :php:class:`Cake\\Http\\Response`.
 
-``Response`` provides an interface to wrap the common response-related
-tasks such as:
+``Response`` ay nagbibigay ng isang interface para balutin ang karaniwang tugon na may kaugnayad
+na mga gawain tulad sa:
 
-* Sending headers for redirects.
-* Sending content type headers.
-* Sending any header.
-* Sending the response body.
+* Pagpapadala ng mga header para sa mga nagre-redirect.
+* Pagpapadala ng nilalaman na uri ng mga header.
+* Pagpapadala sa anumang header.
+* Pagpapadala ng tugon sa katawan.
 
-Dealing with Content Types
---------------------------
+Pakikitungo na may nilalaman na mga uri
+---------------------------------------
 
 .. php:method:: withType($contentType = null)
 
-You can control the Content-Type of your application's responses with
-:php:meth:`Cake\\Http\\Response::withType()`. If your application needs to deal
-with content types that are not built into Response, you can map them with
-``type()`` as well::
+Maaari kang makakontrol ng Content-Type sa iyong mga tugon sa aplikasyon na may
+:php:meth:`Cake\\Http\\Response::withType()`. Kung ang iyong aplikasyon ay nangangailangan na magkasundo
+na may nilalaman na mga uri na hindi itinayo sa Tugon, maaari kang makamapa sa kanila na may
+``type()`` din::
 
-    // Add a vCard type
+    // Magdagdag ng isang vCard na uri
     $this->response->type(['vcf' => 'text/v-card']);
 
-    // Set the response Content-Type to vcard.
+    // Itakda ang tugon na Content-Type sa vcard.
     $this->response = $this->response->withType('vcf');
 
-    // Prior to 3.4.0
+    // Bago ang 3.4.0
     $this->response->type('vcf');
 
-Usually, you'll want to map additional content types in your controller's
-:php:meth:`~Controller::beforeFilter()` callback, so you can leverage the
-automatic view switching features of :php:class:`RequestHandlerComponent` if you
-are using it.
+Karaniwan, gusto mo magmapa sa karagdagang nilalaman na mga uri sa iyong controller sa
+:php:meth:`~Controller::beforeFilter()` na callback, maaari kang gumamit ng
+awtomatiko na view na lumilipat na mga tampok sa :php:class:`RequestHandlerComponent` kung ikaw
+ay gumgamit nito.
 
 .. _cake-response-file:
 
-Sending Files
--------------
+Pagpapadala ng mga File
+-----------------------
 
 .. php:method:: withFile($path, $options = [])
 
-There are times when you want to send files as responses for your requests.
-You can accomplish that by using :php:meth:`Cake\\Http\\Response::withFile()`::
+May mga oras na gusto mong mapadala ng mga file bilang mga tugon para sa iyong mga hiling.
+Maaari mong maisagawa ito sa pamamagitan ng paggamit sa :php:meth:`Cake\\Http\\Response::withFile()`::
 
     public function sendFile($id)
     {
         $file = $this->Attachments->getFile($id);
         $response = $this->response->withFile($file['path']);
-        // Return the response to prevent controller from trying to render
-        // a view.
+        // Binalik ang tugon upang maiwasan ang controller mula sa sinusubukang i-render
+        // ang isang view.
         return $response;
     }
 
-    // Prior to 3.4.0
+    // Bago ang 3.4.0
     $file = $this->Attachments->getFile($id);
     $this->response->file($file['path']);
-    // Return the response to prevent controller from trying to render
-    // a view.
+    // Binalik ang tugon upang pigilan ang kontroller mula sa sinusubukang i-render
+    // ang isang view.
     return $this->response;
 
-As shown in the above example, you must pass the file path to the method.
-CakePHP will send a proper content type header if it's a known file type listed
-in `Cake\\Http\\Reponse::$_mimeTypes`. You can add new types prior to calling
-:php:meth:`Cake\\Http\\Response::withFile()` by using the
-:php:meth:`Cake\\Http\\Response::withType()` method.
+Tulad ng ipinakita sa itaas na halimbawa, kailangan mong magpasa sa file na path sa pamamaraan.
+Ang CakePHP ay nagpapadala ng isang tamang nilalaman na uri ng header kung ito ay kilala na file na uri na naka-lista
+sa `Cake\\Http\\Reponse::$_mimeTypes`. Maaari kang magdagdag ng bagong mga uri bago sa pagtawag sa
+:php:meth:`Cake\\Http\\Response::withFile()` sa pamamagitan sa paggamit ng
+:php:meth:`Cake\\Http\\Response::withType()` na pamamaraan.
 
-If you want, you can also force a file to be downloaded instead of displayed in
-the browser by specifying the options::
+Kung gusto mo, maaari ka ding pilitin ang isang file na ma-download sa halip na ipinapakita sa
+browser sa pamamagitan ng pagtutukoy sa mga opsyon::
 
     $response = $this->response->withFile(
         $file['path'],
         ['download' => true, 'name' => 'foo']
     );
 
-    // Prior to 3.4.0
+    // Bago ang 3.4.0
     $this->response->file(
         $file['path'],
         ['download' => true, 'name' => 'foo']
     );
 
-The supported options are:
+Ang suportado na mga opsyon ay:
 
-name
-    The name allows you to specify an alternate file name to be sent to
-    the user.
+pangalan
+    Ang pangalan ay nagpapahintulot sa iyo ng alternatibong file na pangalan na ipapadala sa
+    gumagamit.
 download
-    A boolean value indicating whether headers should be set to force
-    download.
+    Isang boolean na halaga na nagpapahiwatig kung ang mga header ay dapat itakda upang pilitin
+    ang download.
 
-Sending a String as File
-------------------------
+Pagpapadala ng isang String bilang File
+---------------------------------------
 
-You can respond with a file that does not exist on the disk, such as a pdf or an
-ics generated on the fly from a string::
+Maaari kang tumugon na may isang file na hindi umiiral sa disk, tulad ng isang pdf o isang
+ics na binuo sa nauna mula sa isang string::
 
     public function sendIcs()
     {
@@ -573,96 +573,96 @@ ics generated on the fly from a string::
 
         $response = $response->withType('ics');
 
-        // Optionally force file download
+        // Opsyonal na pinilit ang pag-download ng file
         $response = $response->withDownload('filename_for_download.ics');
 
-        // Return response object to prevent controller from trying to render
-        // a view.
+        // Bumalik na tugon ng object upang pigilan ang controller mula sa sinusubukan pag-render
+        // sa isang .
         return $response;
     }
 
-Callbacks can also return the body as a string::
+Mga callback ay maaari ring bumalik ang katawan bilang isang string::
 
     $path = '/some/file.png';
     $this->response->body(function () use ($path) {
         return file_get_contents($path);
     });
 
-Setting Headers
----------------
+Pagtatakda ng mga Header
+------------------------
 
 .. php:method:: withHeader($header, $value)
 
-Setting headers is done with the :php:meth:`Cake\\Http\\Response::withHeader()`
-method. Like all of the PSR-7 interface methods, this method returns a *new*
-instance with the new header::
+Pagtatakda ng mga header ay nagawa na may :php:meth:`Cake\\Http\\Response::withHeader()`
+na pamamaraan. Tulad ng lahat sa PSR-7 na interface na mga pamamaraan, itong pamaraan ay bumabalik ng *new*
+instance na may bagong header::
 
-    // Add/replace a header
+    // Pagdagdag/pagpalit ng isang header
     $response = $response->withHeader('X-Extra', 'My header');
 
-    // Set multiple headers
+    // Magtakda ng maraming mga header
     $response = $response->withHeader('X-Extra', 'My header')
         ->withHeader('Location', 'http://example.com');
 
-    // Append a value to an existing header
+    // Ilagay ang isang halaga para sa isang umiiral na header
     $response = $response->withAddedHeader('Set-Cookie', 'remember_me=1');
 
-    // Prior to 3.4.0 - Set a header
+    // Bago ang 3.4.0 - Itakda ang isang header
     $this->response->header('Location', 'http://example.com');
 
-Headers are not sent when set. Instead, they are held until the response is
-emitted by ``Cake\Http\Server``.
+Mga headers ay hindi pinadala kung naitakda. Sa halip, sila ay gaganapin hanggang ang tugon ay
+napalabas sa pamamagitan ng ``Cake\Http\Server``.
 
-You can now use the convenience method
-:php:meth:`Cake\\Http\\Response::withLocation()` to directly set or get the
-redirect location header.
+Maaari mo na ngayong gumamit ng kaginhawaan na pamamaraan sa
+:php:meth:`Cake\\Http\\Response::withLocation()` upang direkta na itakda o kunin ang
+pag-redirect na lokasyon na header.
 
-Setting the Body
-----------------
+Pagtatakda sa Katawan
+---------------------
 
 .. php:method:: withStringBody($string)
 
-To set a string as the response body, do the following::
+Ihanda ang isang string bilang tugon na katawan, gawin ang mga sumusunod::
 
-    // Set a string into the body
+    // Itakda ang string sa katawan
     $response = $response->withStringBody('My Body');
 
-    // If you want a json response
+    // Kung gusto mo ng isang json na tugon
     $response = $response->withType('application/json')
         ->withStringBody(json_encode(['Foo' => 'bar']));
 
 .. versionadded:: 3.4.3
-    ``withStringBody()`` was added in 3.4.3
+    ``withStringBody()`` ay idinagdag sa 3.4.3
 
 .. php:method:: withBody($body)
 
-To set the response body, use the ``withBody()`` method, which is provided by the
+Upang itakda ang tugon na katawan, gamitin ang ``withBody()`` na pamamaraan, na ibinigay sa pamamagitan sa
 :php:class:`Zend\\Diactoros\\MessageTrait`::
 
     $response = $response->withBody($stream);
 
-    // Prior to 3.4.0 - Set the body
+    // Bago ang 3.4.0 - Itakda ang Katawan
     $this->response->body('My Body');
 
-Be sure that ``$stream`` is a :php:class:`Psr\\Http\\Message\\StreamInterface` object.
-See below on how to create a new stream.
+Siguraduhin na ang ``$stream`` ay isang :php:class:`Psr\\Http\\Message\\StreamInterface` na object.
+Tingmam sa ibaba kung papaano lumikha ng isang bagong stream.
 
-You can also stream responses from files using :php:class:`Zend\\Diactoros\\Stream` streams::
+Maaari mo ring mag-stream ng mga tugon mula sa mga file na gamit ang :php:class:`Zend\\Diactoros\\Stream` na mga stream::
 
-    // To stream from a file
+    // Upang i-stream mula sa file
     use Zend\Diactoros\Stream;
 
     $stream = new Stream('/path/to/file', 'rb');
     $response = $response->withBody($stream);
 
-You can also stream responses from a callback using the ``CallbackStream``. This
-is useful when you have resources like images, CSV files or PDFs you need to
-stream to the client::
+Maaaring mo ring i-strean ang mga tugon mula sa isang callback gamit ang ``CallbackStream``. Ito
+ay magagamit kapag ikaw ay mayroong mga mapagkukunan tulad ng mga imahe, mga CSV file o mga PDF na kailangan mo
+i-stream sa kliyente::
 
-    // Streaming from a callback
+    // Pag-stream mula sa isang callback
     use Cake\Http\CallbackStream;
 
-    // Create an image.
+    // Lumikha ng imahe.
     $img = imagecreate(100, 100);
     // ...
 
@@ -671,7 +671,7 @@ stream to the client::
     });
     $response = $response->withBody($stream);
 
-    // Prior to 3.4.0 you can use the following to create streaming responses.
+    // Bago ang 3.4.0 maaari kang gumgamit sa sumusunod upang lumikha ng pag-stream na mga tugon.
     $file = fopen('/some/file.png', 'r');
     $this->response->body(function () use ($file) {
         rewind($file);
@@ -679,8 +679,8 @@ stream to the client::
         fclose($file);
     });
 
-Setting the Character Set
--------------------------
+Pagtatakda ng Character Set
+---------------------------
 
 .. php:method:: withCharset($charset)
 
@@ -688,7 +688,7 @@ Sets the charset that will be used in the response::
 
     $this->response = $this->response->withCharset('UTF-8');
 
-    // Prior to 3.4.0
+    // Bago ang 3.4.0
     $this->response->charset('UTF-8');
 
 Interacting with Browser Caching
@@ -696,40 +696,40 @@ Interacting with Browser Caching
 
 .. php:method:: withDisabledCache()
 
-You sometimes need to force browsers not to cache the results of a controller
-action. :php:meth:`Cake\\Http\\Response::withDisabledCache()` is intended for just
-that::
+Kung minsan kailangan mong pilitin ang mga browser na hindi mag-cache ng mga resulta sa isang controller
+na aksyon. :php:meth:`Cake\\Http\\Response::withDisabledCache()` ay nilayon para lamang
+sa ganun::
 
     public function index()
     {
-        // Disable caching
+        // Hindi pinagana ang pag-cache
         $this->response = $this->response->withDisabledCache();
 
-        // Prior to 3.4.0
+        // Bago ang 3.4.0
         $this->response->disableCache();
     }
 
 .. warning::
 
-    Disabling caching from SSL domains while trying to send
-    files to Internet Explorer can result in errors.
+    Ang hindi pagpagana sa pag-cache mula sa SSL na mga domain habang sinusubukang ipadala
+    ang mga file sa Internet Explorer ay maaaring magresulta ng mga pagkakamali.
 
 .. php:method:: withCache($since, $time = '+1 day')
 
-You can also tell clients that you want them to cache responses. By using
-:php:meth:`Cake\\Http\\Response::withCache()`::
+Maaari mo ring sabihin ang mga kliyente na gusto mo sa kanila upang i-cache ang mga tugon. Sa pamamagitan sa paggamit
+ng :php:meth:`Cake\\Http\\Response::withCache()`::
 
     public function index()
     {
-        // Enable caching
+        // Pagpagana sa pag-cache
         $this->response = $this->response->withCache('-1 minute', '+5 days');
     }
 
-The above would tell clients to cache the resulting response for 5 days,
-hopefully speeding up your visitors' experience.
-The ``withCache()`` method sets the ``Last-Modified`` value to the first
-argument. ``Expires`` header and the ``max-age`` directive are set based on the
-second parameter. Cache-Control's ``public`` directive is set as well.
+Ang sabi sa itaas sa mga kliyente upang i-cache ang resultang tugon hanggang sa limang araw,
+sana ay mapadali ang karanasan ng iyong mga binisita.
+Ang ``withCache()`` na pamamaraan ay nagtatakda ng ``Last-Modified`` na halaga para sa unang
+argumento. ``Expires`` na header at ang ``max-age`` na direktiba ay nakabatay batay sa
+pangalawang parameter. Ang pag-cache na pagkokontrol ng ``public`` direktiba ay itinakda rin.
 
 .. _cake-response-caching:
 


### PR DESCRIPTION
Partial Translating File request-response.rst with 1 177 translated words.
Note : Code text and Computer Generated Code Text are not counted as translated words.